### PR TITLE
Added listener to Error and changed the callback.

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,10 +35,17 @@ module.exports = function loadScript (options, callback) {
     // https://github.com/thirdpartyjs/thirdpartyjs-code/blob/master/examples/templates/02/loading-files/index.html
     if (callback && type(callback) === 'function') {
         if (script.addEventListener) {
-            script.addEventListener('load', callback, false);
+            script.addEventListener('load', function (event) {
+                callback(null, event);
+            }, false);
+            script.addEventListener('error', function (event) {
+                callback(new Error('Failed to load the script.'), event);
+            }, false);
         } else if (script.attachEvent) {
-            script.attachEvent('onreadystatechange', function () {
-                if (/complete|loaded/.test(script.readyState)) callback();
+            script.attachEvent('onreadystatechange', function (event) {
+                if (/complete|loaded/.test(script.readyState)) {
+                    callback(null, event);
+                }
             });
         }
     }

--- a/test/index.html
+++ b/test/index.html
@@ -6,6 +6,7 @@
         <div id="mocha"></div>
         <script src="mocha.js"></script>
         <script>mocha.setup({
+            timeout     : 10000,
             ui          : 'qunit',
             ignoreLeaks : true
         })</script>

--- a/test/tests.js
+++ b/test/tests.js
@@ -7,7 +7,8 @@
     suite('load-script');
 
     test('can load by src string with callback', function (done) {
-        load('//cdnjs.cloudflare.com/ajax/libs/angular.js/1.1.1/angular.min.js', function () {
+        load('//cdnjs.cloudflare.com/ajax/libs/angular.js/1.1.1/angular.min.js', function (error, event) {
+            assert(!error);
             done();
         });
     });
@@ -17,17 +18,24 @@
         assert(type(script) === 'element');
     });
 
-
     test('can load protocol-specific src', function (done) {
         var http = 'http://cdnjs.cloudflare.com/ajax/libs/datejs/1.0/date.min.js';
         var https = 'https://cdnjs.cloudflare.com/ajax/libs/datejs/1.0/date.min.js';
         var script = load({
             http  : http,
             https : https
-        }, function () {
+        }, function (error, event) {
+            assert(!error);
             done();
         });
         assert(script.src === http);
+    });
+
+    test('callback passes an error when the script fails to load', function (done) {
+        load('//cdnjs.cloudflare.com/ajax/libs/angular.js/1.1.1/nonexistent.min.js', function (error, event) {
+            assert(error);
+            done();
+        });
     });
 
 }());


### PR DESCRIPTION
Callback is now `(error, event)` and it listens to the error event on the script tag. (#2)

Information on IE compatibility is annoying to dig through. I just changed the callback to be consistent.
