### PR TITLE
component.json: Maintain component 0.x support

### DIFF
--- a/component.json
+++ b/component.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "segmentio/script-onload": "*",
     "component/type": "*",
-    "timoxley/next-tick": "~0.0.2"
+    "timoxley/next-tick": "0.0.2"
   },
   "development": {
     "component/assert": "*"


### PR DESCRIPTION
I've got component@0.19 builds failing due to the `~`.